### PR TITLE
chore: mark theme/ files as linguist-generated with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+theme/* linguist-generated=true


### PR DESCRIPTION
Means that changes to these files aren't shown by default in GitHub's PR files changed view (you click "see diff" to expand the diff).