### PR TITLE
fix: add support for github-flavored alerts, update callout colors

### DIFF
--- a/site/src/components.md
+++ b/site/src/components.md
@@ -24,6 +24,23 @@ This is a dangerous warning.
 This is a details block.
 :::
 
+## GitHub-flavored Alerts
+
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention due to potential risks.
+
+> [!CAUTION]
+> Negative potential consequences of an action.
+
 ## Code Blocks
 
 ```js{1,4,6-8}

--- a/theme/frappe/blue.css
+++ b/theme/frappe/blue.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/blue.css
+++ b/theme/frappe/blue.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/flamingo.css
+++ b/theme/frappe/flamingo.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/flamingo.css
+++ b/theme/frappe/flamingo.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/green.css
+++ b/theme/frappe/green.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/green.css
+++ b/theme/frappe/green.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/lavender.css
+++ b/theme/frappe/lavender.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/lavender.css
+++ b/theme/frappe/lavender.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/maroon.css
+++ b/theme/frappe/maroon.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/maroon.css
+++ b/theme/frappe/maroon.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/mauve.css
+++ b/theme/frappe/mauve.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/mauve.css
+++ b/theme/frappe/mauve.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/peach.css
+++ b/theme/frappe/peach.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/peach.css
+++ b/theme/frappe/peach.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/pink.css
+++ b/theme/frappe/pink.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/pink.css
+++ b/theme/frappe/pink.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/red.css
+++ b/theme/frappe/red.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/red.css
+++ b/theme/frappe/red.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/rosewater.css
+++ b/theme/frappe/rosewater.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/rosewater.css
+++ b/theme/frappe/rosewater.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/sapphire.css
+++ b/theme/frappe/sapphire.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/sapphire.css
+++ b/theme/frappe/sapphire.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/sky.css
+++ b/theme/frappe/sky.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/sky.css
+++ b/theme/frappe/sky.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/teal.css
+++ b/theme/frappe/teal.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/teal.css
+++ b/theme/frappe/teal.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/frappe/yellow.css
+++ b/theme/frappe/yellow.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adce;
 
   /* Callout Colors */
-  --vp-c-default-soft: #414559;
-  --vp-c-tip-soft: hsla(222, 74%, 74%, 0.20);
+  --vp-c-tip-soft: hsla(96, 44%, 68%, 0.20);
   --vp-c-warning-soft: hsla(40, 62%, 73%, 0.20);
   --vp-c-danger-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-caution-soft: hsla(359, 68%, 71%, 0.20);
+  --vp-c-important-soft: hsla(277, 59%, 76%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
+  --vp-custom-block-details-bg: ##414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(65, 69, 89);
   --vp-c-gray-3: rgb(48, 52, 70);
   --vp-c-gray-soft: hsla(229, 19%, 53%, 0.14);
+
+  --vp-c-default-soft: ##414559;
 
   --vp-c-indigo-1: rgb(140, 170, 238);
   --vp-c-indigo-2: rgb(133, 167, 245);

--- a/theme/frappe/yellow.css
+++ b/theme/frappe/yellow.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 48%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(222, 74%, 74%, 0.20);
-  --vp-custom-block-details-bg: ##414559;
+  --vp-custom-block-details-bg: #414559;
 
   /* Catppuccin Accents */
   --ctp-frappe-rosewater: #f2d5cf;

--- a/theme/macchiato/blue.css
+++ b/theme/macchiato/blue.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/blue.css
+++ b/theme/macchiato/blue.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/flamingo.css
+++ b/theme/macchiato/flamingo.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/flamingo.css
+++ b/theme/macchiato/flamingo.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/green.css
+++ b/theme/macchiato/green.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/green.css
+++ b/theme/macchiato/green.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/lavender.css
+++ b/theme/macchiato/lavender.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/lavender.css
+++ b/theme/macchiato/lavender.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/maroon.css
+++ b/theme/macchiato/maroon.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/maroon.css
+++ b/theme/macchiato/maroon.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/mauve.css
+++ b/theme/macchiato/mauve.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/mauve.css
+++ b/theme/macchiato/mauve.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/peach.css
+++ b/theme/macchiato/peach.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/peach.css
+++ b/theme/macchiato/peach.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/pink.css
+++ b/theme/macchiato/pink.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/pink.css
+++ b/theme/macchiato/pink.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/red.css
+++ b/theme/macchiato/red.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/red.css
+++ b/theme/macchiato/red.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/rosewater.css
+++ b/theme/macchiato/rosewater.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/rosewater.css
+++ b/theme/macchiato/rosewater.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/sapphire.css
+++ b/theme/macchiato/sapphire.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/sapphire.css
+++ b/theme/macchiato/sapphire.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/sky.css
+++ b/theme/macchiato/sky.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/sky.css
+++ b/theme/macchiato/sky.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/teal.css
+++ b/theme/macchiato/teal.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/teal.css
+++ b/theme/macchiato/teal.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/macchiato/yellow.css
+++ b/theme/macchiato/yellow.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
-  --vp-custom-block-details-bg: ##363a4f;
+  --vp-custom-block-details-bg: #363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;

--- a/theme/macchiato/yellow.css
+++ b/theme/macchiato/yellow.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a5adcb;
 
   /* Callout Colors */
-  --vp-c-default-soft: #363a4f;
-  --vp-c-tip-soft: hsla(220, 83%, 75%, 0.20);
+  --vp-c-tip-soft: hsla(105, 48%, 72%, 0.20);
   --vp-c-warning-soft: hsla(40, 70%, 78%, 0.20);
   --vp-c-danger-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-caution-soft: hsla(351, 74%, 73%, 0.20);
+  --vp-c-important-soft: hsla(267, 83%, 80%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 60%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 83%, 75%, 0.20);
+  --vp-custom-block-details-bg: ##363a4f;
 
   /* Catppuccin Accents */
   --ctp-macchiato-rosewater: #f4dbd6;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(54, 58, 79);
   --vp-c-gray-3: rgb(36, 39, 58);
   --vp-c-gray-soft: hsla(232, 24%, 49%, 0.14);
+
+  --vp-c-default-soft: ##363a4f;
 
   --vp-c-indigo-1: rgb(138, 173, 244);
   --vp-c-indigo-2: rgb(132, 171, 250);

--- a/theme/mocha/blue.css
+++ b/theme/mocha/blue.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/blue.css
+++ b/theme/mocha/blue.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/flamingo.css
+++ b/theme/mocha/flamingo.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/flamingo.css
+++ b/theme/mocha/flamingo.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/green.css
+++ b/theme/mocha/green.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/green.css
+++ b/theme/mocha/green.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/lavender.css
+++ b/theme/mocha/lavender.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/lavender.css
+++ b/theme/mocha/lavender.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/maroon.css
+++ b/theme/mocha/maroon.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/maroon.css
+++ b/theme/mocha/maroon.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/mauve.css
+++ b/theme/mocha/mauve.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/mauve.css
+++ b/theme/mocha/mauve.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/peach.css
+++ b/theme/mocha/peach.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/peach.css
+++ b/theme/mocha/peach.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/pink.css
+++ b/theme/mocha/pink.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/pink.css
+++ b/theme/mocha/pink.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/red.css
+++ b/theme/mocha/red.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/red.css
+++ b/theme/mocha/red.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/rosewater.css
+++ b/theme/mocha/rosewater.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/rosewater.css
+++ b/theme/mocha/rosewater.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/sapphire.css
+++ b/theme/mocha/sapphire.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/sapphire.css
+++ b/theme/mocha/sapphire.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/sky.css
+++ b/theme/mocha/sky.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/sky.css
+++ b/theme/mocha/sky.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/teal.css
+++ b/theme/mocha/teal.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/teal.css
+++ b/theme/mocha/teal.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/theme/mocha/yellow.css
+++ b/theme/mocha/yellow.css
@@ -38,7 +38,7 @@
 
   --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
   --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
-  --vp-custom-block-details-bg: ##ccd0da;
+  --vp-custom-block-details-bg: #ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -148,7 +148,7 @@
 
   --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
   --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
-  --vp-custom-block-details-bg: ##313244;
+  --vp-custom-block-details-bg: #313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;

--- a/theme/mocha/yellow.css
+++ b/theme/mocha/yellow.css
@@ -30,10 +30,15 @@
   --vp-c-text-3: #6c6f85;
 
   /* Callout Colors */
-  --vp-c-default-soft: #ccd0da;
-  --vp-c-tip-soft: hsla(220, 91%, 54%, 0.20);
+  --vp-c-tip-soft: hsla(109, 58%, 40%, 0.20);
   --vp-c-warning-soft: hsla(35, 77%, 49%, 0.20);
   --vp-c-danger-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-caution-soft: hsla(347, 87%, 44%, 0.20);
+  --vp-c-important-soft: hsla(266, 85%, 58%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(197, 96%, 46%, 0.20);
+  --vp-custom-block-note-bg: hsla(220, 91%, 54%, 0.20);
+  --vp-custom-block-details-bg: ##ccd0da;
 
   /* Catppuccin Accents */
   --ctp-latte-rosewater: #dc8a78;
@@ -68,6 +73,8 @@
   --vp-c-gray-2: rgb(204, 208, 218);
   --vp-c-gray-3: rgb(239, 241, 245);
   --vp-c-gray-soft: hsla(220, 23%, 65%, 0.14);
+
+  --vp-c-default-soft: ##ccd0da;
 
   --vp-c-indigo-1: rgb(30, 102, 245);
   --vp-c-indigo-2: rgb(21, 99, 255);
@@ -133,10 +140,15 @@
   --vp-c-text-3: #a6adc8;
 
   /* Callout Colors */
-  --vp-c-default-soft: #313244;
-  --vp-c-tip-soft: hsla(217, 92%, 76%, 0.20);
+  --vp-c-tip-soft: hsla(115, 54%, 76%, 0.20);
   --vp-c-warning-soft: hsla(41, 86%, 83%, 0.20);
   --vp-c-danger-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-caution-soft: hsla(343, 81%, 75%, 0.20);
+  --vp-c-important-soft: hsla(267, 84%, 81%, 0.20);
+
+  --vp-custom-block-info-bg: hsla(189, 71%, 73%, 0.20);
+  --vp-custom-block-note-bg: hsla(217, 92%, 76%, 0.20);
+  --vp-custom-block-details-bg: ##313244;
 
   /* Catppuccin Accents */
   --ctp-mocha-rosewater: #f5e0dc;
@@ -171,6 +183,8 @@
   --vp-c-gray-2: rgb(49, 50, 68);
   --vp-c-gray-3: rgb(30, 30, 46);
   --vp-c-gray-soft: hsla(240, 21%, 45%, 0.14);
+
+  --vp-c-default-soft: ##313244;
 
   --vp-c-indigo-1: rgb(137, 180, 250);
   --vp-c-indigo-2: rgb(133, 180, 255);

--- a/vitepress.tera
+++ b/vitepress.tera
@@ -67,7 +67,7 @@ whiskers:
 
   --vp-custom-block-info-bg: {{ palette.sky | mod(opacity=0.2) | css_hsla }};
   --vp-custom-block-note-bg: {{ palette.blue | mod(opacity=0.2) | css_hsla }};
-  --vp-custom-block-details-bg: #{{ palette.surface0.hex }};
+  --vp-custom-block-details-bg: {{ palette.surface0.hex }};
 
   /* Catppuccin Accents */
   {% for color_name, color in palette -%}

--- a/vitepress.tera
+++ b/vitepress.tera
@@ -59,10 +59,15 @@ whiskers:
   --vp-c-text-3: {{ palette.subtext0.hex }};
 
   /* Callout Colors */
-  --vp-c-default-soft: {{ palette.surface0.hex }};
-  --vp-c-tip-soft: {{ palette.blue | mod(opacity=0.2) | css_hsla }};
+  --vp-c-tip-soft: {{ palette.green | mod(opacity=0.2) | css_hsla }};
   --vp-c-warning-soft: {{ palette.yellow | mod(opacity=0.2) | css_hsla }};
   --vp-c-danger-soft: {{ palette.red | mod(opacity=0.2) | css_hsla }};
+  --vp-c-caution-soft: {{ palette.red | mod(opacity=0.2) | css_hsla }};
+  --vp-c-important-soft: {{ palette.mauve | mod(opacity=0.2) | css_hsla }};
+
+  --vp-custom-block-info-bg: {{ palette.sky | mod(opacity=0.2) | css_hsla }};
+  --vp-custom-block-note-bg: {{ palette.blue | mod(opacity=0.2) | css_hsla }};
+  --vp-custom-block-details-bg: #{{ palette.surface0.hex }};
 
   /* Catppuccin Accents */
   {% for color_name, color in palette -%}
@@ -90,6 +95,8 @@ whiskers:
   {%- else %}
   --vp-c-gray-soft: {{palette.base | add(lightness=lightness_amount_gray) | mod(opacity=opacity_mod) | css_hsla}};
   {%- endif %}
+
+  --vp-c-default-soft: #{{ palette.surface0.hex }};
 
   --vp-c-indigo-1: {{palette.blue | css_rgb}};
   --vp-c-indigo-2: {{palette.blue | add(saturation=saturation) | css_rgb}};


### PR DESCRIPTION
Firstly adds the GitHub-flavored Alerts syntax, which is in some places themed differently than the normal callouts. Second, adds variables to theme those GitHub alerts (important, caution). Third, adds a more specific var to make info callouts/alerts sky and note callouts/alerts blue (matching our mdBook port), along with a var to reset `<details>` elements back to what they were before (surface0).